### PR TITLE
Load image before album when using direct link

### DIFF
--- a/web/js/012-display.js
+++ b/web/js/012-display.js
@@ -423,12 +423,14 @@ $(document).ready(function() {
 			currentMedia = photo;
 			currentMediaIndex = photoIndex;
 		}
+		
 		setTitle();
-		var populateAlbum = previousAlbum !== currentAlbum || previousMedia !== currentMedia;
-		showAlbum(populateAlbum);
 		if (currentMedia !== null) {
 			showMedia();
 		}
+		var populateAlbum = previousAlbum !== currentAlbum || previousMedia !== currentMedia;
+		showAlbum(populateAlbum);
+		
 		if (typeof poweredByTranslation !== 'undefined')
 			$("#powered-by-string").html(poweredByTranslation);
 		if (typeof loadingTranslation !== 'undefined')


### PR DESCRIPTION
Load the image before album-content, making image show much faster, especially when having large albums.

Fixes #5